### PR TITLE
Updated gitignore and remove the need to create a new "code" folder.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,10 @@
-vc120.pdb
 4ed_data.ctm
 .DS_Store
 *.dSYM
+*.exe
+*.exp
+*.pdb
+*.lib
+*.obj
+*.dll
+*.ilk

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ SOFTWARE.
 6. A. On windows run "bin\build.bat"
    B. On linux run "bin\build-linux.sh"
    C. On linux run "bin\build-mac.sh"
+7. Copy the files in 4coder-non-source/dist_files into the build folder created, you'll need at least the fonts folder. You only have to do this once
 
+Note: If you need to extend the 4ed api, you can run "bin\build_full.bat".
 
 # Notes on Major Issues
 

--- a/README.md
+++ b/README.md
@@ -49,13 +49,12 @@ SOFTWARE.
 
 1. Create an empty folder named "4ed" to contain the codebase.
 2. Clone the repository
-3. Rename the folder containing the repository to "code"
-4. At the same level as the "4ed" folder, clone the "4coder-non-source" repository
-5. A. On windows setup the visual studio command line magic sauce so that "cl" works
+3. At the same level as the "4ed" folder, clone the "4coder-non-source" repository
+4. A. On windows setup the visual studio command line magic sauce so that "cl" works
    B. On linux setup g++
    C. On mac setup clang
-6. Navigate to the "4ed/code" folder.
-7. A. On windows run "bin\build.bat"
+5. Navigate to the "4ed/4cc" folder.
+6. A. On windows run "bin\build.bat"
    B. On linux run "bin\build-linux.sh"
    C. On linux run "bin\build-mac.sh"
 

--- a/bin/4ed_build.cpp
+++ b/bin/4ed_build.cpp
@@ -142,7 +142,7 @@ char **platform_includes[Platform_COUNT][Compiler_COUNT] = {
     {0                      , 0                     , mac_clang_platform_inc},
 };
 
-char *default_custom_target = "../code/custom/4coder_default_bindings.cpp";
+char *default_custom_target = "../4cc/custom/4coder_default_bindings.cpp";
 
 // NOTE(allen): Build flags
 

--- a/bin/4ed_build.cpp
+++ b/bin/4ed_build.cpp
@@ -569,6 +569,18 @@ build_main(Arena *arena, char *cdir, b32 update_local_theme, u32 flags, u32 arch
         fm_clear_folder(themes_folder);
         fm_make_folder_if_missing(arena, themes_folder);
         fm_copy_all(source_themes_folder, themes_folder);
+
+        char *config_files[] = { "ship_files/bindings.4coder",
+                                "../build/bindings.4coder", 
+                                "ship_files/mac-bindings.4coder", 
+                                "../build/mac-bindings.4coder", 
+                                "ship_files/config.4coder",
+                                "../build//config.4coder" };
+
+        for(u32 i = 0; i < ArrayCount(config_files); i +=2) {
+            fm_copy_file(config_files[i], config_files[i + 1]);
+        }
+
     }
     
     fflush(stdout);

--- a/bin/build_full.bat
+++ b/bin/build_full.bat
@@ -1,0 +1,8 @@
+@echo off
+
+call custom\bin\build_one_time.bat 4ed_api_parser_main.cpp
+
+call one_time.exe 4ed_api_implementation.cpp
+
+call bin\build.bat
+


### PR DESCRIPTION
1) After first compilation the root of the project creates a lot of binaries and that just pollutes the git staging section as potential adds. Let's ignore those.

2) It's annoying to have to rename the repo folder to "code", unnecessary extra setup step and that also may confuse git related tools like fork. Since the repo has changed name to 4cc that actually works pretty well.