### PR TITLE
Only execute the replace command when the user input valid query

### DIFF
--- a/code/custom/4coder_base_commands.cpp
+++ b/code/custom/4coder_base_commands.cpp
@@ -1199,13 +1199,15 @@ CUSTOM_DOC("Queries the user for a needle and string. Replaces all occurences of
     Scratch_Block scratch(app);
     Query_Bar_Group group(app);
     String_Pair pair = query_user_replace_pair(app, scratch);
-    for (Buffer_ID buffer = get_buffer_next(app, 0, Access_ReadWriteVisible);
-         buffer != 0;
-         buffer = get_buffer_next(app, buffer, Access_ReadWriteVisible)){
-        Range_i64 range = buffer_range(app, buffer);
-        replace_in_range(app, buffer, range, pair.a, pair.b);
+    if (pair.valid)
+    {
+      for (Buffer_ID buffer = get_buffer_next(app, 0, Access_ReadWriteVisible);
+           buffer != 0;
+           buffer = get_buffer_next(app, buffer, Access_ReadWriteVisible)){
+          Range_i64 range = buffer_range(app, buffer);
+          replace_in_range(app, buffer, range, pair.a, pair.b);
+      }
     }
-    
     global_history_edit_group_end(app);
 }
 


### PR DESCRIPTION
Bug: When user cancel query after calling `replace_in_all_buffers` command the program crashes.