### PR TITLE
Clip characters and rectangles that are outside the screen to avoid sending them to the GPU

### DIFF
--- a/code/4ed_render_target.cpp
+++ b/code/4ed_render_target.cpp
@@ -146,13 +146,26 @@ draw_rectangle_outline(Render_Target *target, Rect_f32 rect, f32 roundness, f32 
     vertices[4].xy = V2f32(rect.x0, rect.y1);
     vertices[5].xy = V2f32(rect.x1, rect.y1);
     
+    // NOTE simon (03/04/24): If any vertex is in the render target bounds, we draw the rectangle.
+    // It would be better to use the current clip rect, but it's not available here. We could pass
+    // it down in the function signature if necessary.
+    Rect_f32 target_rect = Rf32( 0, 0, ( f32 ) target->width, ( f32 ) target->height );
+    b32 draw = false;
+    
     Vec2_f32 center = rect_center(rect);
     for (i32 i = 0; i < ArrayCount(vertices); i += 1){
         vertices[i].uvw = V3f32(center.x, center.y, roundness);
         vertices[i].color = color;
         vertices[i].half_thickness = half_thickness;
+        
+        draw = draw || rect_contains_point( target_rect, vertices[ i ].xy );
     }
-    draw__write_vertices_in_current_group(target, vertices, ArrayCount(vertices));
+    
+    draw = true;
+    
+    if ( draw ) {
+        draw__write_vertices_in_current_group(target, vertices, ArrayCount(vertices));
+    }
 }
 
 internal void
@@ -235,12 +248,24 @@ draw_font_glyph(Render_Target *target, Face *face, u32 codepoint, Vec2_f32 p,
     vertices[3] = vertices[1];
     vertices[4] = vertices[2];
     
+    // NOTE simon (03/04/24): If any vertex is in the render target bounds, we draw the rectangle.
+    // It would be better to use the current clip rect, but it's not available here. We could pass
+    // it down in the function signature if necessary.
+    Rect_f32 target_rect = Rf32( 0, 0, ( f32 ) target->width, ( f32 ) target->height );
+    b32 draw = false;
+    
     for (i32 i = 0; i < ArrayCount(vertices); i += 1){
         vertices[i].color = color;
         vertices[i].half_thickness = 0.f;
+        
+        draw = draw || rect_contains_point( target_rect, vertices[ i ].xy );
     }
     
-    draw__write_vertices_in_current_group(target, vertices, ArrayCount(vertices));
+    draw = true;
+    
+    if ( draw ) {
+        draw__write_vertices_in_current_group(target, vertices, ArrayCount(vertices));
+    }
 }
 
 ////////////////////////////////

--- a/code/4ed_render_target.cpp
+++ b/code/4ed_render_target.cpp
@@ -146,22 +146,24 @@ draw_rectangle_outline(Render_Target *target, Rect_f32 rect, f32 roundness, f32 
     vertices[4].xy = V2f32(rect.x0, rect.y1);
     vertices[5].xy = V2f32(rect.x1, rect.y1);
     
-    // NOTE simon (03/04/24): If any vertex is in the render target bounds, we draw the rectangle.
-    // It would be better to use the current clip rect, but it's not available here. We could pass
-    // it down in the function signature if necessary.
-    Rect_f32 target_rect = Rf32( 0, 0, ( f32 ) target->width, ( f32 ) target->height );
-    b32 draw = false;
-    
     Vec2_f32 center = rect_center(rect);
     for (i32 i = 0; i < ArrayCount(vertices); i += 1){
         vertices[i].uvw = V3f32(center.x, center.y, roundness);
         vertices[i].color = color;
         vertices[i].half_thickness = half_thickness;
-        
-        draw = draw || rect_contains_point( target_rect, vertices[ i ].xy );
     }
     
-    draw = true;
+    // NOTE simon (03/04/24): If any vertex is in the render target bounds, we draw the rectangle.
+    // It would be better to use the current clip rect, but it's not available here. We could pass
+    // it down in the function signature if necessary.
+    // This is not in the loop to try minimize the impact it could have on performance when there
+    // are a lot of vertex (we don't test duplicated vertex positions).
+    Rect_f32 target_rect = Rf32( 0, 0, ( f32 ) target->width, ( f32 ) target->height );
+    b32 draw = false;
+    draw = draw || rect_contains_point( target_rect, vertices[ 0 ].xy );
+    draw = draw || rect_contains_point( target_rect, vertices[ 1 ].xy );
+    draw = draw || rect_contains_point( target_rect, vertices[ 2 ].xy );
+    draw = draw || rect_contains_point( target_rect, vertices[ 5 ].xy );
     
     if ( draw ) {
         draw__write_vertices_in_current_group(target, vertices, ArrayCount(vertices));
@@ -248,20 +250,22 @@ draw_font_glyph(Render_Target *target, Face *face, u32 codepoint, Vec2_f32 p,
     vertices[3] = vertices[1];
     vertices[4] = vertices[2];
     
-    // NOTE simon (03/04/24): If any vertex is in the render target bounds, we draw the rectangle.
-    // It would be better to use the current clip rect, but it's not available here. We could pass
-    // it down in the function signature if necessary.
-    Rect_f32 target_rect = Rf32( 0, 0, ( f32 ) target->width, ( f32 ) target->height );
-    b32 draw = false;
-    
     for (i32 i = 0; i < ArrayCount(vertices); i += 1){
         vertices[i].color = color;
         vertices[i].half_thickness = 0.f;
-        
-        draw = draw || rect_contains_point( target_rect, vertices[ i ].xy );
     }
     
-    draw = true;
+    // NOTE simon (03/04/24): If any vertex is in the render target bounds, we draw the rectangle.
+    // It would be better to use the current clip rect, but it's not available here. We could pass
+    // it down in the function signature if necessary.
+    // This is not in the loop to try minimize the impact it could have on performance when there
+    // are a lot of vertex (we don't test duplicated vertex positions).
+    Rect_f32 target_rect = Rf32( 0, 0, ( f32 ) target->width, ( f32 ) target->height );
+    b32 draw = false;
+    draw = draw || rect_contains_point( target_rect, vertices[ 0 ].xy );
+    draw = draw || rect_contains_point( target_rect, vertices[ 1 ].xy );
+    draw = draw || rect_contains_point( target_rect, vertices[ 2 ].xy );
+    draw = draw || rect_contains_point( target_rect, vertices[ 5 ].xy );
     
     if ( draw ) {
         draw__write_vertices_in_current_group(target, vertices, ArrayCount(vertices));

--- a/code/4ed_render_target.cpp
+++ b/code/4ed_render_target.cpp
@@ -132,40 +132,30 @@ end_render_section(Render_Target *target){
 
 internal void
 draw_rectangle_outline(Render_Target *target, Rect_f32 rect, f32 roundness, f32 thickness, u32 color){
-    if (roundness < epsilon_f32){
-        roundness = 0.f;
-    }
-    thickness = clamp_bot(1.f, thickness);
-    f32 half_thickness = thickness*0.5f;
     
-    Render_Vertex vertices[6] = {};
-    vertices[0].xy = V2f32(rect.x0, rect.y0);
-    vertices[1].xy = V2f32(rect.x1, rect.y0);
-    vertices[2].xy = V2f32(rect.x0, rect.y1);
-    vertices[3].xy = V2f32(rect.x1, rect.y0);
-    vertices[4].xy = V2f32(rect.x0, rect.y1);
-    vertices[5].xy = V2f32(rect.x1, rect.y1);
-    
-    Vec2_f32 center = rect_center(rect);
-    for (i32 i = 0; i < ArrayCount(vertices); i += 1){
-        vertices[i].uvw = V3f32(center.x, center.y, roundness);
-        vertices[i].color = color;
-        vertices[i].half_thickness = half_thickness;
-    }
-    
-    // NOTE simon (03/04/24): If any vertex is in the render target bounds, we draw the rectangle.
-    // It would be better to use the current clip rect, but it's not available here. We could pass
-    // it down in the function signature if necessary.
-    // This is not in the loop to try minimize the impact it could have on performance when there
-    // are a lot of vertex (we don't test duplicated vertex positions).
-    Rect_f32 target_rect = Rf32( 0, 0, ( f32 ) target->width, ( f32 ) target->height );
-    b32 draw = false;
-    draw = draw || rect_contains_point( target_rect, vertices[ 0 ].xy );
-    draw = draw || rect_contains_point( target_rect, vertices[ 1 ].xy );
-    draw = draw || rect_contains_point( target_rect, vertices[ 2 ].xy );
-    draw = draw || rect_contains_point( target_rect, vertices[ 5 ].xy );
-    
-    if ( draw ) {
+    if ( rect_overlap(rect, target->current_clip_box) ) {
+            
+        if (roundness < epsilon_f32){
+            roundness = 0.f;
+        }
+        thickness = clamp_bot(1.f, thickness);
+        f32 half_thickness = thickness*0.5f;
+        
+        Render_Vertex vertices[6] = {};
+        vertices[0].xy = V2f32(rect.x0, rect.y0);
+        vertices[1].xy = V2f32(rect.x1, rect.y0);
+        vertices[2].xy = V2f32(rect.x0, rect.y1);
+        vertices[3].xy = V2f32(rect.x1, rect.y0);
+        vertices[4].xy = V2f32(rect.x0, rect.y1);
+        vertices[5].xy = V2f32(rect.x1, rect.y1);
+        
+        Vec2_f32 center = rect_center(rect);
+        for (i32 i = 0; i < ArrayCount(vertices); i += 1){
+            vertices[i].uvw = V3f32(center.x, center.y, roundness);
+            vertices[i].color = color;
+            vertices[i].half_thickness = half_thickness;
+        }
+        
         draw__write_vertices_in_current_group(target, vertices, ArrayCount(vertices));
     }
 }
@@ -209,65 +199,60 @@ draw_font_glyph(Render_Target *target, Face *face, u32 codepoint, Vec2_f32 p,
     vertices[2].xy = p_x_min + y_max;
     vertices[5].xy = p_x_max + y_max;
     
-#if 0    
-    Vec2_f32 xy_min = p + bounds.xy_off.x0*x_axis + bounds.xy_off.y0*y_axis;
-    Vec2_f32 xy_max = p + bounds.xy_off.x1*x_axis + bounds.xy_off.y1*y_axis;
-    
-    vertices[0].xy = V2f32(xy_min.x, xy_min.y);
-    vertices[1].xy = V2f32(xy_max.x, xy_min.y);
-    vertices[2].xy = V2f32(xy_min.x, xy_max.y);
-    vertices[5].xy = V2f32(xy_max.x, xy_max.y);
-#endif
-    
-#if 0    
-    if (!HasFlag(flags, GlyphFlag_Rotate90)){
-        Rect_f32 xy = Rf32(p + bounds.xy_off.p0, p + bounds.xy_off.p1);
-        
-        vertices[0].xy  = V2f32(xy.x0, xy.y1);
-        vertices[0].uvw = V3f32(uv.x0, uv.y1, bounds.w);
-        vertices[1].xy  = V2f32(xy.x1, xy.y1);
-        vertices[1].uvw = V3f32(uv.x1, uv.y1, bounds.w);
-        vertices[2].xy  = V2f32(xy.x0, xy.y0);
-        vertices[2].uvw = V3f32(uv.x0, uv.y0, bounds.w);
-        vertices[5].xy  = V2f32(xy.x1, xy.y0);
-        vertices[5].uvw = V3f32(uv.x1, uv.y0, bounds.w);
-    }
-    else{
-        Rect_f32 xy = Rf32(p.x - bounds.xy_off.y1, p.y + bounds.xy_off.x0,
-                           p.x - bounds.xy_off.y0, p.y + bounds.xy_off.x1);
-        
-        vertices[0].xy  = V2f32(xy.x0, xy.y1);
-        vertices[0].uvw = V3f32(uv.x1, uv.y1, bounds.w);
-        vertices[1].xy  = V2f32(xy.x1, xy.y1);
-        vertices[1].uvw = V3f32(uv.x1, uv.y0, bounds.w);
-        vertices[2].xy  = V2f32(xy.x0, xy.y0);
-        vertices[2].uvw = V3f32(uv.x0, uv.y1, bounds.w);
-        vertices[5].xy  = V2f32(xy.x1, xy.y0);
-        vertices[5].uvw = V3f32(uv.x0, uv.y0, bounds.w);
-    }
-#endif
-    
-    vertices[3] = vertices[1];
-    vertices[4] = vertices[2];
-    
-    for (i32 i = 0; i < ArrayCount(vertices); i += 1){
-        vertices[i].color = color;
-        vertices[i].half_thickness = 0.f;
-    }
-    
-    // NOTE simon (03/04/24): If any vertex is in the render target bounds, we draw the rectangle.
-    // It would be better to use the current clip rect, but it's not available here. We could pass
-    // it down in the function signature if necessary.
-    // This is not in the loop to try minimize the impact it could have on performance when there
-    // are a lot of vertex (we don't test duplicated vertex positions).
-    Rect_f32 target_rect = Rf32( 0, 0, ( f32 ) target->width, ( f32 ) target->height );
-    b32 draw = false;
-    draw = draw || rect_contains_point( target_rect, vertices[ 0 ].xy );
-    draw = draw || rect_contains_point( target_rect, vertices[ 1 ].xy );
-    draw = draw || rect_contains_point( target_rect, vertices[ 2 ].xy );
-    draw = draw || rect_contains_point( target_rect, vertices[ 5 ].xy );
+    /* NOTE simon (26/09/24): We don't use rect_overlap here because the text rect is not guaranteed to be axis aligned. */
+    b32 draw = rect_contains_point( target->current_clip_box, vertices[ 0 ].xy );
+    draw  = draw || rect_contains_point( target->current_clip_box, vertices[ 1 ].xy );
+    draw  = draw || rect_contains_point( target->current_clip_box, vertices[ 2 ].xy );
+    draw  = draw || rect_contains_point( target->current_clip_box, vertices[ 5 ].xy );
     
     if ( draw ) {
+    
+#if 0    
+        Vec2_f32 xy_min = p + bounds.xy_off.x0*x_axis + bounds.xy_off.y0*y_axis;
+        Vec2_f32 xy_max = p + bounds.xy_off.x1*x_axis + bounds.xy_off.y1*y_axis;
+        
+        vertices[0].xy = V2f32(xy_min.x, xy_min.y);
+        vertices[1].xy = V2f32(xy_max.x, xy_min.y);
+        vertices[2].xy = V2f32(xy_min.x, xy_max.y);
+        vertices[5].xy = V2f32(xy_max.x, xy_max.y);
+#endif
+        
+#if 0    
+        if (!HasFlag(flags, GlyphFlag_Rotate90)){
+            Rect_f32 xy = Rf32(p + bounds.xy_off.p0, p + bounds.xy_off.p1);
+            
+            vertices[0].xy  = V2f32(xy.x0, xy.y1);
+            vertices[0].uvw = V3f32(uv.x0, uv.y1, bounds.w);
+            vertices[1].xy  = V2f32(xy.x1, xy.y1);
+            vertices[1].uvw = V3f32(uv.x1, uv.y1, bounds.w);
+            vertices[2].xy  = V2f32(xy.x0, xy.y0);
+            vertices[2].uvw = V3f32(uv.x0, uv.y0, bounds.w);
+            vertices[5].xy  = V2f32(xy.x1, xy.y0);
+            vertices[5].uvw = V3f32(uv.x1, uv.y0, bounds.w);
+        }
+        else{
+            Rect_f32 xy = Rf32(p.x - bounds.xy_off.y1, p.y + bounds.xy_off.x0,
+                               p.x - bounds.xy_off.y0, p.y + bounds.xy_off.x1);
+            
+            vertices[0].xy  = V2f32(xy.x0, xy.y1);
+            vertices[0].uvw = V3f32(uv.x1, uv.y1, bounds.w);
+            vertices[1].xy  = V2f32(xy.x1, xy.y1);
+            vertices[1].uvw = V3f32(uv.x1, uv.y0, bounds.w);
+            vertices[2].xy  = V2f32(xy.x0, xy.y0);
+            vertices[2].uvw = V3f32(uv.x0, uv.y1, bounds.w);
+            vertices[5].xy  = V2f32(xy.x1, xy.y0);
+            vertices[5].uvw = V3f32(uv.x0, uv.y0, bounds.w);
+        }
+#endif
+        
+        vertices[3] = vertices[1];
+        vertices[4] = vertices[2];
+        
+        for (i32 i = 0; i < ArrayCount(vertices); i += 1){
+            vertices[i].color = color;
+            vertices[i].half_thickness = 0.f;
+        }
+        
         draw__write_vertices_in_current_group(target, vertices, ArrayCount(vertices));
     }
 }


### PR DESCRIPTION
4coder at the moment doesn't clip (on the CPU side) vertices that are outside the screen horizontally. For example if a file with very long lines is loaded and line wrapping is disabled (or not wrapping because there is no space in line), 4coder will send all the character to the graphics card. This can cause higher than normal GPU memory usage, and poor performances with problematic files.
4coder doesn't clip vertices vertically either, but several systems in 4coder have "limits" vertically. For example, early out of listers when Y is outside the screen, or the rendering system processing only the line range that's visible on screen vertically.

This modification, adds a test in the functions that push rectangles and characters in the rendering pipeline to avoid pushing rectangles that are totally out of the screen (horizontally or vertically). This solves the GPU memory usage issue, and reduces the performance issue. The performances are still not great as we still have to test each rectangles, so files with very long lines are still problematic. Non problematic files shouldn't see much of a performance impact, although I haven't measured it.

The clip rectangle used is 4coder render group rectangle (which is the client rectangle of the window). A better version of this would be to use the current clip rectangle, but that information is not passed down to the functions modified in this commit. I would not expect the gain to be great, but it could be done if necessary.

A better solution to the problem would be to use the layout system to "clip" lines at a higher level, but the layout system is complicated enough that I don't feel confident modifying it.

As a side note, I tried modifying the layout system to be able to wrap lines with no space, by wrapping after comma, semicolon, colon and parenthesis (at the moment 4coder will only wrap line on spaces). This solved the memory issue, but then the file layout function(s) became a performance bottleneck that seemed worse than the current performance issue. Also I found out that not wrapping lines if there are no space was useful to me for editing the files with very long lines, as navigating the file is much easier with few lines.