### PR TITLE
Fix inclusion of `<immintrin.h>` on M1 mac

### DIFF
--- a/code/custom/4coder_audio.cpp
+++ b/code/custom/4coder_audio.cpp
@@ -6,7 +6,11 @@
 #include <immintrin.h>
 #define _InterlockedExchangeAdd __sync_fetch_and_add
 #elif OS_MAC
+#if ARCH_ARM64
+#define _mm_pause() __builtin_arm_yield()
+#else
 #include <immintrin.h>
+#endif
 #define _InterlockedExchangeAdd __sync_fetch_and_add
 #else
 #include <intrin.h>


### PR DESCRIPTION
Partial fix for https://github.com/4coder-community/4cc/issues/17

The prebuilt `libfreetype-mac.a` is still x64 so you’ll fail to link.