### PR TITLE
undo/redo can clear dirty state

### DIFF
--- a/code/4ed_edit.cpp
+++ b/code/4ed_edit.cpp
@@ -368,6 +368,9 @@ edit_change_current_history_state(Thread_Context *tctx, Models *models, Editing_
         }
         
         file->state.current_record_index = current;
+        if (file->state.saved_record_index == current){
+            RemFlag(file->state.dirty, DirtyState_UnsavedChanges);
+        }
     }
 }
 

--- a/code/4ed_file.cpp
+++ b/code/4ed_file.cpp
@@ -157,6 +157,7 @@ save_file_to_name(Thread_Context *tctx, Models *models, Editing_File *file, u8 *
         File_Attributes new_attributes = system_save_file(scratch, (char*)file_name, saveable_string);
         if (new_attributes.last_write_time > 0 &&
             using_actual_file_name){
+            file->state.saved_record_index = file->state.current_record_index;
             file->state.save_state = FileSaveState_SavedWaitingForNotification;
             file_clear_dirty_flags(file);
         }

--- a/code/4ed_file.h
+++ b/code/4ed_file.h
@@ -53,6 +53,7 @@ struct Editing_File_State{
     
     History history;
     i32 current_record_index;
+    i32 saved_record_index;
     
     Dirty_State dirty;
     File_Save_State save_state;


### PR DESCRIPTION
This was on the list for 4coder_qol, but it makes way more sense to do this in the core