### PR TITLE
changed – to - on line 3057

### DIFF
--- a/non-source/foreign/freetype2/freetype/freetype.h
+++ b/non-source/foreign/freetype2/freetype/freetype.h
@@ -3054,7 +3054,7 @@ FT_BEGIN_HEADER
   /*    this does not translate to 50% brightness for that pixel on our    */
   /*    sRGB and gamma~2.2 screens.  Due to their non-linearity, they      */
   /*    dwell longer in the darks and only a pixel value of about 186      */
-  /*    results in 50% brightness – 128 ends up too dark on both bright    */
+  /*    results in 50% brightness - 128 ends up too dark on both bright    */
   /*    and dark backgrounds.  The net result is that dark text looks      */
   /*    burnt-out, pixely and blotchy on bright background, bright text    */
   /*    too frail on dark backgrounds, and colored text on colored         */


### PR DESCRIPTION
its just 1 character that causes a warning
![image](https://github.com/user-attachments/assets/7801ed5d-24a0-4a56-b132-cfe0657bb833)
