### PR TITLE
Update opengl version to 3.2 on linux and update glsl version to 150, so that mac opengl renderer can compile shaders.

### DIFF
--- a/code/opengl/4ed_opengl_render.cpp
+++ b/code/opengl/4ed_opengl_render.cpp
@@ -68,7 +68,7 @@ gl__error_callback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsiz
     }
 }
 
-char *gl__header = R"foo(#version 130
+char *gl__header = R"foo(#version 150
         )foo";
 
 char *gl__vertex = R"foo(

--- a/code/platform_linux/linux_4ed.cpp
+++ b/code/platform_linux/linux_4ed.cpp
@@ -700,8 +700,8 @@ glx_create_context(GLXFBConfig fb_config){
         ctx = glXCreateNewContext(linuxvars.dpy, fb_config, GLX_RGBA_TYPE, 0, True);
     } else {
         static const int context_attribs[] = {
-            GLX_CONTEXT_MAJOR_VERSION_ARB, 2,
-            GLX_CONTEXT_MINOR_VERSION_ARB, 1,
+            GLX_CONTEXT_MAJOR_VERSION_ARB, 3,
+            GLX_CONTEXT_MINOR_VERSION_ARB, 2,
             GLX_CONTEXT_PROFILE_MASK_ARB , GLX_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB,
 #if GL_DEBUG_MODE
             GLX_CONTEXT_FLAGS_ARB        , GLX_CONTEXT_DEBUG_BIT_ARB,

--- a/code/platform_linux/linux_4ed.cpp
+++ b/code/platform_linux/linux_4ed.cpp
@@ -709,7 +709,6 @@ glx_create_context(GLXFBConfig fb_config){
             None
         };
         
-        //LOG("Creating GL 2.1 context... ");
         ctx = glXCreateContextAttribsARB(linuxvars.dpy, fb_config, 0, True, context_attribs);
     }
     


### PR DESCRIPTION
GLSL 150 is the version that corresponds to opengl 3.2.

On Mac the OpenGL renderer fails to compile shaders because it doesn't support glsl 130.

Mac doesn't support a compatibility layer for versions less than 3.2. [https://www.khronos.org/opengl/wiki/OpenGL_Context#OpenGL_3.2_and_Profiles](https://www.khronos.org/opengl/wiki/OpenGL_Context#OpenGL_3.2_and_Profiles):

>Platform Issue (MacOSX): When MacOSX 10.7 introduced support for OpenGL beyond 2.1, they also introduced the core/compatibility dichotomy. However, they did not introduce support for the compatibility profile itself. Instead, MacOSX gives you a choice: core profile for versions 3.2 or higher, or just version 2.1. There is no way to get access to features after 2.1 and still access the [Fixed Function Pipeline](https://www.khronos.org/opengl/wiki/Fixed_Function_Pipeline).

On mac my 4coder creates a opengl 4.1 context.

On linux I get a 4.2 (compatibility profile) before and after the changes.

And on windows I get 3.2, which is specifically requested. 
https://github.com/4coder-community/4cc/blob/925df2b49e41144f8bba68d910e8a655fee53e90/code/platform_win32/win32_opengl.cpp#L214C1-L224C15
```cpp
            i32 context_attrib_list[] = {
                /*0*/WGL_CONTEXT_MAJOR_VERSION_ARB, 3,
                /*2*/WGL_CONTEXT_MINOR_VERSION_ARB, 2,
                /*4*/WGL_CONTEXT_FLAGS_ARB, WGL_CONTEXT_FORWARD_COMPATIBLE_BIT_ARB
#if GL_DEBUG_MODE
                |WGL_CONTEXT_DEBUG_BIT_ARB
#endif
                ,
                /*6*/WGL_CONTEXT_PROFILE_MASK_ARB, WGL_CONTEXT_CORE_PROFILE_BIT_ARB,
                /*8*/0
            };
```
