### PR TITLE
Handle KeyRelease and MouseButtonRelease events

### DIFF
--- a/code/4ed_font_provider_freetype.cpp
+++ b/code/4ed_font_provider_freetype.cpp
@@ -319,8 +319,7 @@ ft__font_make_face(Arena *arena, Face_Description *description, f32 scale_factor
         white.data = white_data;
         
         Bad_Rect_Pack pack = {};
-        // ft__bad_rect_pack_init(&pack, V2i32(1024, 1024));
-        ft__bad_rect_pack_init(&pack, V2i32(128, 128));
+        ft__bad_rect_pack_init(&pack, V2i32(1024, 1024));
         ft__glyph_bounds_store_uv_raw(ft__bad_rect_pack_next(&pack, white.dim), white.dim, &face->white);
         for (u16 i = 0; i < index_count; i += 1){
             Vec2_i32 dim = glyph_bitmaps[i].dim;
@@ -355,9 +354,6 @@ ft__font_make_face(Arena *arena, Face_Description *description, f32 scale_factor
             face->bounds[i].uv.y1 = (face->bounds[i].uv.y0 + face->bounds[i].uv.y1)/texture_dim.y;
             face->bounds[i].uv.x0 =  face->bounds[i].uv.x0/texture_dim.x;
             face->bounds[i].uv.y0 =  face->bounds[i].uv.y0/texture_dim.y;
-#if 0
-            face->bounds[i].w /= texture_dim.z;
-#endif
         }
         
         {

--- a/code/4ed_font_provider_freetype.cpp
+++ b/code/4ed_font_provider_freetype.cpp
@@ -162,10 +162,7 @@ ft__bad_rect_pack_next(Bad_Rect_Pack *pack, Vec2_i32 dim){
         }
         
         // NOTE(simon, 28/02/24): We are now sure that the character will fit.
-        
-        if ( pack->current_line_h < dim.y ) {
-            pack->current_line_h = dim.y;
-        }
+        pack->current_line_h = Max(pack->current_line_h, dim.y);
         
         result = pack->p;
         pack->p.x += dim.x;
@@ -200,7 +197,7 @@ ft__font_make_face(Arena *arena, Face_Description *description, f32 scale_factor
     if (error == 0){
         face = push_array_zero(arena, Face, 1);
         
-        u32 pt_size_unscaled = Max(description->parameters.pt_size, 8); 
+        u32 pt_size_unscaled = Max(description->parameters.pt_size, 8);
         u32 pt_size = (u32)(pt_size_unscaled*scale_factor);
         b32 hinting = description->parameters.hinting;
         
@@ -322,7 +319,8 @@ ft__font_make_face(Arena *arena, Face_Description *description, f32 scale_factor
         white.data = white_data;
         
         Bad_Rect_Pack pack = {};
-        ft__bad_rect_pack_init(&pack, V2i32(1024, 1024));
+        // ft__bad_rect_pack_init(&pack, V2i32(1024, 1024));
+        ft__bad_rect_pack_init(&pack, V2i32(128, 128));
         ft__glyph_bounds_store_uv_raw(ft__bad_rect_pack_next(&pack, white.dim), white.dim, &face->white);
         for (u16 i = 0; i < index_count; i += 1){
             Vec2_i32 dim = glyph_bitmaps[i].dim;
@@ -357,7 +355,9 @@ ft__font_make_face(Arena *arena, Face_Description *description, f32 scale_factor
             face->bounds[i].uv.y1 = (face->bounds[i].uv.y0 + face->bounds[i].uv.y1)/texture_dim.y;
             face->bounds[i].uv.x0 =  face->bounds[i].uv.x0/texture_dim.x;
             face->bounds[i].uv.y0 =  face->bounds[i].uv.y0/texture_dim.y;
+#if 0
             face->bounds[i].w /= texture_dim.z;
+#endif
         }
         
         {

--- a/code/custom/4coder_command_map.cpp
+++ b/code/custom/4coder_command_map.cpp
@@ -236,9 +236,22 @@ map_get_event_breakdown(Input_Event *event){
             result.skip_self_mod = event->key.code;
         }break;
         
+        case InputEventKind_KeyRelease:
+        {
+            result.key = mapping__key(InputEventKind_KeyRelease, event->key.code);
+            result.mod_set = &event->key.modifiers;
+            result.skip_self_mod = event->key.code;
+        }break;
+        
         case InputEventKind_MouseButton:
         {
             result.key = mapping__key(InputEventKind_MouseButton, event->mouse.code);
+            result.mod_set = &event->mouse.modifiers;
+        }break;
+        
+        case InputEventKind_MouseButtonRelease:
+        {
+            result.key = mapping__key(InputEventKind_MouseButtonRelease, event->mouse.code);
             result.mod_set = &event->mouse.modifiers;
         }break;
         

--- a/code/custom/4coder_events.cpp
+++ b/code/custom/4coder_events.cpp
@@ -92,9 +92,11 @@ get_modifiers(Input_Event *event){
     Input_Modifier_Set *result = 0;
     switch (event->kind){
         case InputEventKind_KeyStroke:
+        case InputEventKind_KeyRelease:
         {
             result = &event->key.modifiers;
         }break;
+        case InputEventKind_MouseButtonRelease:
         case InputEventKind_MouseButton:
         {
             result = &event->mouse.modifiers;
@@ -173,6 +175,11 @@ to_writable(Input_Event *event){
 function b32
 match_key_code(Input_Event *event, Key_Code code){
     return(event->kind == InputEventKind_KeyStroke && event->key.code == code);
+}
+
+function b32
+match_key_code_release(Input_Event *event, Key_Code code){
+    return(event->kind == InputEventKind_KeyRelease && event->key.code == code);
 }
 
 function b32

--- a/code/metal/4ed_metal_render.mm
+++ b/code/metal/4ed_metal_render.mm
@@ -510,8 +510,8 @@ metal__make_buffer(u32 size, id<MTLDevice> device){
         texture_descriptor.pixelFormat = MTLPixelFormatR8Unorm;
         texture_descriptor.width = dim.x;
         texture_descriptor.height = dim.y;
-        texture_descriptor.depth = dim.z;
-        
+        texture_descriptor.arrayLength = dim.z;
+
         // NOTE(yuval): Create the texture from the device using the descriptor and add it to the textures array.
         Metal_Texture texture = [_device newTextureWithDescriptor:texture_descriptor];
         texture_slot->texture = texture;
@@ -531,17 +531,21 @@ metal__make_buffer(u32 size, id<MTLDevice> device){
             Metal_Texture texture = texture_slot->texture;
             
             if (texture != 0){
+                // https://developer.apple.com/documentation/metal/mtlregion
+                // for 2d texture origin.z is 0, and depth is 1
                 MTLRegion replace_region = {
-                    {(NSUInteger)p.x, (NSUInteger)p.y, (NSUInteger)p.z},
-                    {(NSUInteger)dim.x, (NSUInteger)dim.y, (NSUInteger)dim.z}
+                    {(NSUInteger)p.x, (NSUInteger)p.y, 0},
+                    {(NSUInteger)dim.x, (NSUInteger)dim.y, 1}
                 };
                 
                 // NOTE(yuval): Fill the texture with data
                 [texture replaceRegion:replace_region
                         mipmapLevel:0
+                        slice:p.z
                         withBytes:data
-                        bytesPerRow:dim.x];
-                
+                        bytesPerRow:dim.x
+                        bytesPerImage:0];
+
                 result = true;
             }
         }

--- a/code/platform_win32/4ed_dx11_render.cpp
+++ b/code/platform_win32/4ed_dx11_render.cpp
@@ -561,7 +561,9 @@ gl_render(Render_Target *t){
         Rect_i32 box = Ri32(group->clip_box);
         
         // NOTE(FS): Ignore this group if we our scissor rectangle is not well defined
-        if ((rect_width(box) <= 0) || (rect_height(box) <= 0)) continue;
+        if ((rect_width(box) <= 0) || (rect_height(box) <= 0)) {
+            continue;
+        }
         
         D3D11_RECT group_scissor = { };
         group_scissor.left = box.x0;

--- a/code/platform_win32/4ed_dx11_render.cpp
+++ b/code/platform_win32/4ed_dx11_render.cpp
@@ -154,7 +154,7 @@ gl__fill_texture(Texture_Kind texture_kind, u32 texid, Vec3_i32 p, Vec3_i32 dim,
     // font rendering code and other platforms. Fortunately the only call that specified 0 for the
     // texture handle was for the creation of the fallback texture in gl_render, and we can modify
     // that call to pass the fallback texture handle.
-    Assert( texid != 0 ); 
+    Assert( texid != 0 );
     
     if (dim.x > 0 && dim.y > 0 && dim.z > 0){
         
@@ -220,20 +220,20 @@ struct output_t {
 };
 
 output_t main(input_t input) {
-	
+
     output_t output;
 
     output.position = float4( mul( view_m, ( input.vertex_p - view_t ) ), 0.0, 1.0 );
     // NOTE(simon, 28/02/24): The input colors are BGRA, we need them as RGBA.
     output.color = input.vertex_c.zyxw;
     output.uvw = input.vertex_t;
-	output.xy = input.vertex_p;
-	output.half_thickness = input.vertex_ht;
-	
+    output.xy = input.vertex_p;
+    output.half_thickness = input.vertex_ht;
+
     float2 center = input.vertex_t.xy;
     float2 half_dim = abs( input.vertex_p - center );
     output.adjusted_half_dim = half_dim - input.vertex_t.zz + float2( 0.5, 0.5 );
-    
+
     return output;
 }
 )foo";

--- a/code/platform_win32/4ed_dx11_render.cpp
+++ b/code/platform_win32/4ed_dx11_render.cpp
@@ -560,6 +560,9 @@ gl_render(Render_Target *t){
          group = group->next){
         Rect_i32 box = Ri32(group->clip_box);
         
+        // NOTE(FS): Ignore this group if we our scissor rectangle is not well defined
+        if ((rect_width(box) <= 0) || (rect_height(box) <= 0)) continue;
+        
         D3D11_RECT group_scissor = { };
         group_scissor.left = box.x0;
         group_scissor.right = box.x1;


### PR DESCRIPTION
`map_get_event_breakdown` in `custom/4coder_command_map.cpp` didn't handle release events.
It is used in `map_get_binding_recursive/non_recursive`, which in turn is used in a few places. While being able to bind commands to release events (BindRelease/BindMouseRelease are supplied, and `BindMouseRelease` is even used in `setup_essential_mapping`), they never got handled.

To test it very easily you could change `code/custom/4coder_default_framework.cpp:597:5` from `BindMouseRelease(click_set_cursor, MouseCode_Left);` into `BindMouseRelease(interactive_open, MouseCode_Left);`.

When I'm there I searched for other places that have incomplete switch cases and found `get_modifiers`, so I added handling for it in there as well.