### PR TITLE
Handle KeyRelease and MouseButtonRelease events

### DIFF
--- a/code/custom/4coder_command_map.cpp
+++ b/code/custom/4coder_command_map.cpp
@@ -236,9 +236,22 @@ map_get_event_breakdown(Input_Event *event){
             result.skip_self_mod = event->key.code;
         }break;
         
+        case InputEventKind_KeyRelease:
+        {
+            result.key = mapping__key(InputEventKind_KeyRelease, event->key.code);
+            result.mod_set = &event->key.modifiers;
+            result.skip_self_mod = event->key.code;
+        }break;
+        
         case InputEventKind_MouseButton:
         {
             result.key = mapping__key(InputEventKind_MouseButton, event->mouse.code);
+            result.mod_set = &event->mouse.modifiers;
+        }break;
+        
+        case InputEventKind_MouseButtonRelease:
+        {
+            result.key = mapping__key(InputEventKind_MouseButtonRelease, event->mouse.code);
             result.mod_set = &event->mouse.modifiers;
         }break;
         

--- a/code/custom/4coder_events.cpp
+++ b/code/custom/4coder_events.cpp
@@ -92,9 +92,11 @@ get_modifiers(Input_Event *event){
     Input_Modifier_Set *result = 0;
     switch (event->kind){
         case InputEventKind_KeyStroke:
+        case InputEventKind_KeyRelease:
         {
             result = &event->key.modifiers;
         }break;
+        case InputEventKind_MouseButtonRelease:
         case InputEventKind_MouseButton:
         {
             result = &event->mouse.modifiers;
@@ -173,6 +175,11 @@ to_writable(Input_Event *event){
 function b32
 match_key_code(Input_Event *event, Key_Code code){
     return(event->kind == InputEventKind_KeyStroke && event->key.code == code);
+}
+
+function b32
+match_key_code_release(Input_Event *event, Key_Code code){
+    return(event->kind == InputEventKind_KeyRelease && event->key.code == code);
 }
 
 function b32


### PR DESCRIPTION
`map_get_event_breakdown` in `custom/4coder_command_map.cpp` didn't handle release events.
It is used in `map_get_binding_recursive/non_recursive`, which in turn is used in a few places. While being able to bind commands to release events (BindRelease/BindMouseRelease are supplied, and `BindMouseRelease` is even used in `setup_essential_mapping`), they never got handled.

To test it very easily you could change `code/custom/4coder_default_framework.cpp:597:5` from `BindMouseRelease(click_set_cursor, MouseCode_Left);` into `BindMouseRelease(interactive_open, MouseCode_Left);`.

When I'm there I searched for other places that have incomplete switch cases and found `get_modifiers`, so I added handling for it in there as well.