### PR TITLE
Refactor of 4ed_build

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @org/Maintainers

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,19 +11,19 @@ jobs:
         include:
         - suffix: x64-win-dx11
           os: windows-latest
-          build_cmd: bin\package.bat /DWIN32_DX11
+          build_cmd: bin\build.bat /DWIN32_DX11
         - suffix: x64-win-gl
           os: windows-latest
-          build_cmd: bin\package.bat /DWIN32_OPENGL
+          build_cmd: bin\build.bat /DWIN32_OPENGL
         - suffix: x64-linux
           os: ubuntu-latest
-          build_cmd: sudo apt update -y && sudo apt install build-essential libx11-dev libxfixes-dev libglx-dev mesa-common-dev libasound2-dev libfreetype-dev libfontconfig-dev -y && ./bin/package-linux.sh
+          build_cmd: sudo apt update -y && sudo apt install build-essential libx11-dev libxfixes-dev libglx-dev mesa-common-dev libasound2-dev libfreetype-dev libfontconfig-dev -y && ./bin/build-linux.sh
         - suffix: x64-mac
           os: macos-15-intel
-          build_cmd: ./bin/package-mac.sh
-#       - suffix: arm64-mac
-#         os: macos-latest
-#         build_cmd: ./bin/package_arm64-mac.sh
+          build_cmd: ./bin/build-mac.sh
+        # - suffix: arm64-mac
+        #   os: macos-latest
+        #   build_cmd: arch -arch x86_64 ./bin/build-mac.sh
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -34,5 +34,5 @@ jobs:
       uses: actions/upload-artifact@v4.6.0
       with:
         name: 4cc-${{ matrix.suffix }}
-        path: current_dist_super_x64/4coder/  # having "x64" in path might have to change
+        path: build/
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,7 @@
 1. Setup the MSVC toolchain in your environment, this can be done with the `code/custom/bin/setup_cl_x64.bat` script
 2. call the `package.bat` script from the code directory (this builds a distribution in the `distributions` directory with all the non-binary dependencies)
    1. `$ cd 4cc\code`
-   2. `.\bin\package.bat`
-3. You can also use the `build.bat` script if you want just build the binaries (this produces the build artifacts in the `build` directory, this doesn't produce a functional distribution)
-   1. `$ cd 4cc\code`
-   2. `$ .\bin\build.bat`
+   2. `.\bin\build.bat`
 
 In addition to the parameter listed below, you can specify which backend to use by passing one of those parameters to the build scripts:
 - `/DWIN32_OPENGL` (default) to use the OpenGL backend.
@@ -22,10 +19,6 @@ In addition to the parameter listed below, you can specify which backend to use 
     - `$ sudo apt install build-essential libx11-dev libxfixes-dev libglx-dev mesa-common-dev libasound2-dev libfreetype-dev libfontconfig-dev`
 2. Use the `package-linux.sh` script from the code directory (this builds a distribution in the `distributions` directory with all the non-binary dependencies)
    1. `$ cd 4cc/code`
-   2. `$ ./bin/package-linux.sh`
-
-3. You can also use the `build-linux.sh` script if you want just build the binaries, (this produces the build artifacts in the `build` directory, this doesn't produce a functional distribution)
-   1. `$ cd 4cc/code`
    2. `$ ./bin/build-linux.sh`
 
 ## Mac 
@@ -34,11 +27,7 @@ In addition to the parameter listed below, you can specify which backend to use 
 
 1. Use the `package-mac.sh` script from the code directory (this builds a distribution in the `distributions` directory with all the non-binary dependencies)
    1. `$ cd 4cc/code`
-   2. `$ ./bin/package-mac.sh` 
-
-2. You can also use the `build-mac.sh` script if you want just build the binaries, (this produces the build artifacts in the `build` directory, this doesn't produce a functional distribution)
-   1. `$ cd 4cc/code`
-   2. `$ ./bin/build-mac.sh`
+   2. `$ ./bin/build-mac.sh` 
 
 ### Older Macs, 10.15.7 Catalina
 

--- a/README.md
+++ b/README.md
@@ -3,31 +3,50 @@
 # Building
 
 ## Windows
-1. Setup the MSVC toolchain in your environment, this can be done with the `code/custom/bin/setup_cl_x64.bat` script
-2. call the `package.bat` script from the code directory (this builds a distribution in the `distributions` directory with all the non-binary dependencies)
-   1. `$ cd 4cc\code`
-   2. `.\bin\build.bat`
+
+> [!NOTE]
+> 4coder needs the MSVC compiler and windows SDK from the "Desktop development with C++" component. If you don’t have this already, you can download the installer [here](https://visualstudio.microsoft.com/downloads/). Make sure to at least click on "Desktop development with C++" and tick the boxes for MSVC and the Windows SDK.
+
+1. Setup the MSVC toolchain in your environment, this can be done either with the `code/custom/bin/setup_cl_x64.bat` script or by using the development shell in windows terminal
+2. Execute this command from the root of the project (the resulting executable will be under the `build` folder in the root of the repo)
+
+```batch
+cd code && .\bin\build.bat
+```
 
 In addition to the parameter listed below, you can specify which backend to use by passing one of those parameters to the build scripts:
 - `/DWIN32_OPENGL` (default) to use the OpenGL backend.
 - `/DWIN32_DX11` to use the Direct3D 11 backend.
 
+```batch
+cd code && .\bin\build.bat /DWIN32_DX11
+```
+
 ## Linux
+
 > tested on Ubuntu 22.04:
 
 1. Get required libraries (apt names):
-    - `$ sudo apt install build-essential libx11-dev libxfixes-dev libglx-dev mesa-common-dev libasound2-dev libfreetype-dev libfontconfig-dev`
-2. Use the `package-linux.sh` script from the code directory (this builds a distribution in the `distributions` directory with all the non-binary dependencies)
-   1. `$ cd 4cc/code`
-   2. `$ ./bin/build-linux.sh`
+
+```sh
+sudo apt install build-essential libx11-dev libxfixes-dev libglx-dev mesa-common-dev libasound2-dev libfreetype-dev libfontconfig-dev`
+```
+
+2. Execute this command from the root of the project (the resulting executable will be under the `build` folder in the root of the repo)
+
+```sh
+cd code && ./bin/build-linux.sh
+```
 
 ## Mac 
 
 > 4coder targets x86_64. If you are using a M1+ ARM CPU you need to prefix the build scripts commands with: `arch -arch x86_64`
 
-1. Use the `package-mac.sh` script from the code directory (this builds a distribution in the `distributions` directory with all the non-binary dependencies)
-   1. `$ cd 4cc/code`
-   2. `$ ./bin/build-mac.sh` 
+1. Execute this command from the root of the project (the resulting executable will be under the `build` folder in the root of the repo)
+
+```sh
+cd code && ./bin/build-mac.sh
+```
 
 ### Older Macs, 10.15.7 Catalina
 
@@ -40,20 +59,12 @@ If you are using an older version of mac, such as 10.15.7 Catalina you need to i
 ## Build script parameter
 
 The build script accepts a parameter (mutually exclusive):
-- `/DDEV_BUILD` or `/DDEV_BUILD_X86` (default value) : build without optimizations.
+- `/DDEV_BUILD` (default value) : build without optimizations.
    Produces debug symbols.
    Defines: `FRED_INTERNAL`, `FRED_SUPER`, `DO_CRAZY_EXPENSIVE_ASSERTS` (on Windows) macros.
-- `/DOPT_BUILD` or `/DOPT_BUILD_X86` (similar to `build_optimized` script): build with optimizations.
+- `/DOPT_BUILD` (similar to `build_optimized` script): build with optimizations.
    Doesn't produce debug symbols.
    Defines `FRED_SUPER` macro.
-- `/DPACKAGE_SUPER_X64` or `/DPACKAGE_SUPER_X86` (similar to `package` script): package 4coder for distribution.
-   Turns on optimizations.
-   Produces debug symbols.
-   Defines `SHIP_MODE`, `FRED_SUPER`, `DO_CRAZY_EXPENSIVE_ASSERTS` (on Windows) macros.
-- `/DPACKAGE_DEMO_X64` or `/DPACKAGE_DEMO_X86`: packages 4coder demo for distribution.
-   Turns on optimizations.
-   Produces debug symbols.
-   Defines `SHIP_MODE`, `DO_CRAZY_EXPENSIVE_ASSERTS` (on Windows) macros.
    
 ## API generators
 

--- a/code/bin/4ed_build.cpp
+++ b/code/bin/4ed_build.cpp
@@ -498,20 +498,6 @@ build(Arena *arena, u32 flags, u32 arch, char *code_path, char *code_file, char 
     build(arena, flags, arch, code_path, code_files, out_path, out_file, defines, exports, inc_folders);
 }
 
-// https://stackoverflow.com/questions/152016/detecting-cpu-architecture-compile-time
-internal Arch_Code
-get_architecture() {
-    #if defined(__x86_64__) || defined(_M_X64)
-        return Arch_X64;
-    #elif defined(i386) || defined(__i386__) || defined(__i386) || defined(_M_IX86)
-        return Arch_X86;
-    #elif defined(__aarch64__) || defined(_M_ARM64)
-        return Arch_arm64;
-    #else
-        #error Unknown architecture
-    #endif
-}
-
 function void
 dispatch_build(Arena *arena, u32 arch, char *cwd, u32 flags, char** dist_files, i32 dist_file_count){
     Temp_Dir temp = fm_pushdir(fm_str(arena, BUILD_DIR));
@@ -533,7 +519,7 @@ dispatch_build(Arena *arena, u32 arch, char *cwd, u32 flags, char** dist_files, 
     }
     char *build_script = fm_str(arena, "custom/bin/buildsuper_", arch_names[arch], build_script_postfix, BAT);
     
-    char *build_command = fm_str(arena, "\"", cwd, "/", build_script, "\" \"", default_custom_target, "\"");
+    char *build_command = fm_str(arena, "\"", cwd, SLASH, build_script, "\" \"", default_custom_target, "\"");
     if (This_OS == Platform_Windows){
         build_command = fm_str(arena, "call ", build_command);
     }
@@ -574,7 +560,14 @@ int main(int argc, char **argv){
     Assert(n < sizeof(cwd));
     
     u32 flags = 0;
-    u32 arch = get_architecture();
+
+#if ARCH_X86 
+    u32 arch = Arch_X86;
+#elif ARCH_X64
+    u32 arch = Arch_X64;
+#elif ARCH_ARM64
+    u32 arch = Arch_arm64;
+#endif
 
 #if defined(DEV_BUILD)
     flags |= DEBUG_INFO | INTERNAL;

--- a/code/bin/4ed_build.cpp
+++ b/code/bin/4ed_build.cpp
@@ -524,6 +524,10 @@ dispatch_build(Arena *arena, u32 arch, char *cwd, u32 flags, char** dist_files, 
         build_command = fm_str(arena, "call ", build_command);
     }
 
+    if (flags & OPTIMIZATION) {
+        build_command = fm_str(arena, build_command, " release");
+    }
+
     systemf("%s", build_command);
     
     fm_popdir(temp);

--- a/code/bin/4ed_build.cpp
+++ b/code/bin/4ed_build.cpp
@@ -61,6 +61,7 @@ typedef u32 Arch_Code;
 enum{
     Arch_X64,
     Arch_X86,
+    Arch_arm64,
     
     //
     Arch_COUNT,
@@ -70,6 +71,7 @@ enum{
 char *arch_names[] = {
     "x64",
     "x86",
+    "arm64",
 };
 
 #if OS_WINDOWS
@@ -96,13 +98,12 @@ char *arch_names[] = {
 // Universal directories
 //
 
-#define BUILD_DIR "../build"
-#define SITE_DIR "../site"
+#define BUILD_DIR ".." SLASH "build"
+#define SITE_DIR ".." SLASH "site"
 
-#define FOREIGN "../non-source/foreign"
-#define FOREIGN_WIN "..\\non-source\\foreign"
+#define FOREIGN ".." SLASH "non-source" SLASH "foreign"
 
-char *includes[] = { "custom", FOREIGN "/freetype2", 0, };
+char *includes[] = { "custom", FOREIGN SLASH "freetype2", 0, };
 
 //
 // Platform layer file tables
@@ -129,7 +130,7 @@ char **platform_includes[Platform_COUNT][Compiler_COUNT] = {
     {0                      , 0                     , mac_clang_platform_inc},
 };
 
-char *default_custom_target = "../code/custom/4coder_default_bindings.cpp";
+char *default_custom_target = ".." SLASH "code" SLASH "custom" SLASH "4coder_default_bindings.cpp";
 
 // NOTE(allen): Build flags
 
@@ -187,8 +188,8 @@ get_defines_from_flags(Arena *arena, u32 flags){
 #define CL_LIBS_BACKEND " OpenGL32.lib"
 #endif
 
-#define CL_LIBS_X64 CL_LIBS_COMMON FOREIGN_WIN "\\x64\\freetype.lib" CL_LIBS_BACKEND
-#define CL_LIBS_X86 CL_LIBS_COMMON FOREIGN_WIN "\\x86\\freetype.lib" CL_LIBS_BACKEND
+#define CL_LIBS_X64 CL_LIBS_COMMON FOREIGN "\\x64\\freetype.lib" CL_LIBS_BACKEND
+#define CL_LIBS_X86 CL_LIBS_COMMON FOREIGN "\\x86\\freetype.lib" CL_LIBS_BACKEND
 
 #define CL_ICON "..\\non-source\\res\\icon.res"
 
@@ -497,177 +498,117 @@ build(Arena *arena, u32 flags, u32 arch, char *code_path, char *code_file, char 
     build(arena, flags, arch, code_path, code_files, out_path, out_file, defines, exports, inc_folders);
 }
 
-internal void
-build_and_run(Arena *arena, char *cdir, char *filename, char *name, u32 flags){
-    char *dir = fm_str(arena, BUILD_DIR);
-    
-    {
-        char *file = fm_str(arena, filename);
-        build(arena, flags, Arch_X64, cdir, file, dir, name, get_defines_from_flags(arena, flags), 0, includes);
-    }
-    
-    if (prev_error == 0){
-        char *cmd = fm_str(arena, dir, "/", name);
-        fm_execute_in_dir(cdir, cmd, 0);
-    }
-}
-
-internal char*
-get_4coder_dist_name(Arena *arena, u32 platform, u32 arch){
-    char *name = fm_str(arena, "4coder-" MAJOR_STR "-" MINOR_STR "-" PATCH_STR);
-    if (platform != Platform_None){
-        name = fm_str(arena, name, "-", platform_names[platform]);
-    }
-    if (arch != Arch_None){
-        name = fm_str(arena, name, "-", arch_names[arch]);
-    }
-    return(name);
+// https://stackoverflow.com/questions/152016/detecting-cpu-architecture-compile-time
+internal Arch_Code
+get_architecture() {
+    #if defined(__x86_64__) || defined(_M_X64)
+        return Arch_X64;
+    #elif defined(i386) || defined(__i386__) || defined(__i386) || defined(_M_IX86)
+        return Arch_X86;
+    #elif defined(__aarch64__) || defined(_M_ARM64)
+        return Arch_arm64;
+    #else
+        #error Unknown architecture
+    #endif
 }
 
 function void
-package_for_arch(Arena *arena, u32 arch, char *cdir, char *build_dir, u32 flags, char** dist_files, i32 dist_file_count){
-    char *arch_name  = arch_names[arch];
-    char *parent_dir = fm_str(arena, build_dir, SLASH, arch_name);
-    char *dir        = fm_str(arena, parent_dir, SLASH "4coder");
-    char *zip_dir    = parent_dir;
+dispatch_build(Arena *arena, u32 arch, char *cwd, u32 flags, char** dist_files, i32 dist_file_count){
+    Temp_Dir temp = fm_pushdir(fm_str(arena, BUILD_DIR));
     
-    printf("\nBUILD: 4coder_%s\n", arch_name);
-    printf(" dir = %s;\n", dir);
+    char *build_script_postfix = "";
+    switch (This_OS){
+        case Platform_Windows:
+        {
+            build_script_postfix = "-win";
+        }break;
+        case Platform_Linux:
+        {
+            build_script_postfix = "-linux";
+        }break;
+        case Platform_Mac:
+        {
+            build_script_postfix = "-mac";
+        }break;
+    }
+    char *build_script = fm_str(arena, "custom/bin/buildsuper_", arch_names[arch], build_script_postfix, BAT);
+    
+    char *build_command = fm_str(arena, "\"", cwd, "/", build_script, "\" \"", default_custom_target, "\"");
+    if (This_OS == Platform_Windows){
+        build_command = fm_str(arena, "call ", build_command);
+    }
+
+    systemf("%s", build_command);
+    
+    fm_popdir(temp);
     fflush(stdout);
-    
-    { // build super
-        char* file = fm_str(arena, default_custom_target);
 
-        printf(" cdir = %s;\n file = %s;\n arch = %s;\n", cdir, file, arch_names[arch]);
-        fflush(stdout);
-        
-        Temp_Dir temp = fm_pushdir(fm_str(arena, BUILD_DIR));
-        
-        char *build_script_postfix = "";
-        switch (This_OS){
-            case Platform_Windows:
-            {
-                build_script_postfix = "-win";
-            }break;
-            case Platform_Linux:
-            {
-                build_script_postfix = "-linux";
-            }break;
-            case Platform_Mac:
-            {
-                build_script_postfix = "-mac";
-            }break;
-        }
-        char *build_script = fm_str(arena, "custom/bin/buildsuper_", arch_names[arch], build_script_postfix, BAT);
-        
-        char *build_command = fm_str(arena, "\"", cdir, "/", build_script, "\" \"", file, "\"");
-        if (This_OS == Platform_Windows){
-            build_command = fm_str(arena, "call ", build_command);
-        }
-        systemf("%s", build_command);
-        
-        fm_popdir(temp);
-        fflush(stdout);
-    }
-
-    { // build main
-        {
-            char *file = fm_str(arena, "4ed_app_target.cpp");
-            char **exports = fm_list_one_item(arena, "app_get_functions");
-            
-            char **build_includes = includes;
-            
-            build(arena, OPTS | SHARED_CODE | flags, arch, cdir, file, build_dir, "4ed_app" DLL, get_defines_from_flags(arena, flags), exports, build_includes);
-        }
-        
-        {
-            char **inc = (char**)fm_list(arena, includes, platform_includes[This_OS][This_Compiler]);
-            build(arena, OPTS | LIBS | ICON | flags, arch, cdir, platform_layers[This_OS], build_dir, "4ed", get_defines_from_flags(arena, flags), 0, inc);
-        }
-        
-        fflush(stdout);
+    {
+        char *file = fm_str(arena, "4ed_app_target.cpp");
+        char **exports = fm_list_one_item(arena, "app_get_functions");
+        build(arena, OPTS | SHARED_CODE | flags, arch, cwd, file, BUILD_DIR, "4ed_app" DLL, get_defines_from_flags(arena, flags), exports, includes);
     }
     
-    fm_clear_folder(parent_dir);
-    fm_make_folder_if_missing(arena, parent_dir);
+    {
+        char **inc = (char**)fm_list(arena, includes, platform_includes[This_OS][This_Compiler]);
+        build(arena, OPTS | LIBS | ICON | flags, arch, cwd, platform_layers[This_OS], BUILD_DIR, "4ed", get_defines_from_flags(arena, flags), 0, inc);
+    }
     
-    fm_make_folder_if_missing(arena, dir);
-    fm_copy_file(fm_str(arena, build_dir, "/4ed" EXE), fm_str(arena, dir, "/4ed" EXE));
-    fm_copy_file(fm_str(arena, build_dir, "/4ed_app" DLL), fm_str(arena, dir, "/4ed_app" DLL));
-    fm_copy_file(fm_str(arena, build_dir, "/custom_4coder" DLL), fm_str(arena, dir, "/custom_4coder" DLL));
+    fflush(stdout);
     
     for (i32 j = 0; j < dist_file_count; j += 1){
-        fm_copy_all(dist_files[j], dir);
+        fm_copy_all(dist_files[j], BUILD_DIR);
     }
     
-    char *custom_src_dir = fm_str(arena, cdir, SLASH, "custom");
-    char *custom_dst_dir = fm_str(arena, dir, SLASH, "custom");
+    char *custom_src_dir = fm_str(arena, cwd, SLASH, "custom");
+    char *custom_dst_dir = fm_str(arena, BUILD_DIR, SLASH, "custom");
     fm_make_folder_if_missing(arena, custom_dst_dir);
     fm_copy_all(custom_src_dir, custom_dst_dir);
-    
-    char *dist_name = get_4coder_dist_name(arena, This_OS, arch);
-    char *zip_name = fm_str(arena, zip_dir, SLASH, dist_name, ".zip");
-    fm_make_folder_if_missing(arena, zip_dir);
-    fm_zip(parent_dir, "4coder", zip_name);
-}
-
-internal void
-package(Arena *arena, char *cdir, Arch_Code arch){
-    // NOTE(allen): meta
-    char *build_dir = fm_str(arena, BUILD_DIR);
-    char *dist_files[2];
-    dist_files[0] = fm_str(arena, "../non-source/dist_files");
-    dist_files[1] = fm_str(arena, "ship_files");
-    
-    printf("build dir: %s\n", build_dir);
-    printf("dist files: %s, %s\n", dist_files[0], dist_files[1]);
-    fflush(stdout);
-    
-    u32 flags = SHIP | DEBUG_INFO | OPTIMIZATION;
-    
-#if OS_WINDOWS
-#if defined( WIN32_DX11 )
-    flags |= DX11;
-#else
-    flags |= OPENGL;
-#endif
-#endif
-    
-    Temp_Memory temp = begin_temp(arena);
-    package_for_arch(arena, arch, cdir, build_dir, flags, dist_files, ArrayCount(dist_files));
-    end_temp(temp);
 }
 
 int main(int argc, char **argv){
     Arena arena = fm_init_system(DetailLevel_FileOperations);
     
-    char cdir[256];
-    i32 n = fm_get_current_directory(cdir, sizeof(cdir));
-    Assert(n < sizeof(cdir));
+    char cwd[256];
+    i32 n = fm_get_current_directory(cwd, sizeof(cwd));
+    Assert(n < sizeof(cwd));
     
-    u32 flags = SUPER;
-    u32 arch = Arch_X64;
-#if defined(DEV_BUILD) || defined(DEV_BUILD_X86)
+    u32 flags = 0;
+    u32 arch = get_architecture();
+
+#if defined(DEV_BUILD)
     flags |= DEBUG_INFO | INTERNAL;
 #endif
-#if defined(OPT_BUILD) || defined(OPT_BUILD_X86)
-    flags |= OPTIMIZATION;
+
+#if defined(OPT_BUILD)
+    flags |= OPTIMIZATION | SHIP;
 #endif
+
 #if OS_WINDOWS
-#if defined(WIN32_DX11)
-    flags |= DX11;
-#else
-    flags |= OPENGL;
+    #if defined(WIN32_DX11)
+        flags |= DX11;
+    #else
+        flags |= OPENGL;
+    #endif
 #endif
-#endif
-#if defined(DEV_BUILD_X86) || defined(OPT_BUILD_X86)
-    arch = Arch_X86;
-#endif
+
+    // NOTE(allen): meta
+    char *dist_files[] = {
+        fm_str(&arena, "../non-source/dist_files"),
+        fm_str(&arena, "ship_files"),
+    };
     
-    package(&arena, cdir, arch);
+    printf("cwd: %s\n", cwd);
+    printf("BUILD: 4coder\n");
+    printf(" arch: %s\n", arch_names[arch]);
+    printf(" build dir: %s\n", BUILD_DIR);
+    fflush(stdout);
+    
+    Temp_Memory temp = begin_temp(&arena);
+    dispatch_build(&arena, arch, cwd, flags, dist_files, ArrayCount(dist_files));
+    end_temp(temp);
     
     return(error_state);
 }
 
 // BOTTOM
-

--- a/code/bin/4ed_build.cpp
+++ b/code/bin/4ed_build.cpp
@@ -97,7 +97,6 @@ char *arch_names[] = {
 //
 
 #define BUILD_DIR "../build"
-#define PACK_DIR "../distributions"
 #define SITE_DIR "../site"
 
 #define FOREIGN "../non-source/foreign"
@@ -526,16 +525,14 @@ get_4coder_dist_name(Arena *arena, u32 platform, u32 arch){
 }
 
 function void
-package_for_arch(Arena *arena, u32 arch, char *cdir, char *build_dir, char *pack_dir, char *current_dist, u32 flags, char** dist_files, i32 dist_file_count){
+package_for_arch(Arena *arena, u32 arch, char *cdir, char *build_dir, u32 flags, char** dist_files, i32 dist_file_count){
     char *arch_name  = arch_names[arch];
-    char *parent_dir = fm_str(arena, current_dist, "_", arch_name);
+    char *parent_dir = fm_str(arena, build_dir, SLASH, arch_name);
     char *dir        = fm_str(arena, parent_dir, SLASH "4coder");
-    char *zip_dir    = fm_str(arena, pack_dir, SLASH, "4coder_", arch_name);
+    char *zip_dir    = parent_dir;
     
     printf("\nBUILD: 4coder_%s\n", arch_name);
-    printf(" parent_dir = %s;\n", parent_dir);
     printf(" dir = %s;\n", dir);
-    printf(" zip_dir = %s;\n", zip_dir);
     fflush(stdout);
     
     { // build super
@@ -618,13 +615,11 @@ internal void
 package(Arena *arena, char *cdir, Arch_Code arch){
     // NOTE(allen): meta
     char *build_dir = fm_str(arena, BUILD_DIR);
-    char *pack_dir = fm_str(arena, PACK_DIR);
     char *dist_files[2];
     dist_files[0] = fm_str(arena, "../non-source/dist_files");
     dist_files[1] = fm_str(arena, "ship_files");
     
     printf("build dir: %s\n", build_dir);
-    printf("pack dir: %s\n", pack_dir);
     printf("dist files: %s, %s\n", dist_files[0], dist_files[1]);
     fflush(stdout);
     
@@ -638,11 +633,8 @@ package(Arena *arena, char *cdir, Arch_Code arch){
 #endif
 #endif
     
-    fm_make_folder_if_missing(arena, pack_dir);
-    
     Temp_Memory temp = begin_temp(arena);
-    char *current_dist = fm_str(arena, ".." SLASH "current_dist");
-    package_for_arch(arena, arch, cdir, build_dir, pack_dir, current_dist, flags, dist_files, ArrayCount(dist_files));
+    package_for_arch(arena, arch, cdir, build_dir, flags, dist_files, ArrayCount(dist_files));
     end_temp(temp);
 }
 

--- a/code/bin/4ed_build.cpp
+++ b/code/bin/4ed_build.cpp
@@ -25,18 +25,6 @@
 // OS and compiler index
 //
 
-typedef u32 Tier_Code;
-enum{
-    Tier_Demo,
-    Tier_Super,
-    Tier_COUNT,
-};
-
-char *tier_names[] = {
-    "demo",
-    "super",
-};
-
 typedef u32 Platform_Code;
 enum{
     Platform_Windows,
@@ -588,15 +576,9 @@ build_main(Arena *arena, char *cdir, b32 update_local_theme, u32 flags, u32 arch
     fflush(stdout);
 }
 
-internal void
-standard_build(Arena *arena, char *cdir, u32 flags, u32 arch){
-    buildsuper(arena, cdir, fm_str(arena, default_custom_target), arch);
-    build_main(arena, cdir, true, flags, arch);
-}
-
 internal char*
-get_4coder_dist_name(Arena *arena, u32 platform, char *tier, u32 arch){
-    char *name = fm_str(arena, "4coder-" MAJOR_STR "-" MINOR_STR "-" PATCH_STR "-", tier);
+get_4coder_dist_name(Arena *arena, u32 platform, u32 arch){
+    char *name = fm_str(arena, "4coder-" MAJOR_STR "-" MINOR_STR "-" PATCH_STR);
     if (platform != Platform_None){
         name = fm_str(arena, name, "-", platform_names[platform]);
     }
@@ -607,13 +589,13 @@ get_4coder_dist_name(Arena *arena, u32 platform, char *tier, u32 arch){
 }
 
 function void
-package_for_arch(Arena *arena, u32 arch, char *cdir, char *build_dir, char *pack_dir, i32 tier, char *tier_name,  char *current_dist_tier, u32 flags, char** dist_files, i32 dist_file_count){
+package_for_arch(Arena *arena, u32 arch, char *cdir, char *build_dir, char *pack_dir, char *current_dist, u32 flags, char** dist_files, i32 dist_file_count){
     char *arch_name  = arch_names[arch];
-    char *parent_dir = fm_str(arena, current_dist_tier, "_", arch_name);
+    char *parent_dir = fm_str(arena, current_dist, "_", arch_name);
     char *dir        = fm_str(arena, parent_dir, SLASH "4coder");
-    char *zip_dir    = fm_str(arena, pack_dir, SLASH, tier_name, "_", arch_name);
+    char *zip_dir    = fm_str(arena, pack_dir, SLASH, "4coder_", arch_name);
     
-    printf("\nBUILD: %s_%s\n", tier_name, arch_name);
+    printf("\nBUILD: 4coder_%s\n", arch_name);
     printf(" parent_dir = %s;\n", parent_dir);
     printf(" dir = %s;\n", dir);
     printf(" zip_dir = %s;\n", zip_dir);
@@ -630,41 +612,23 @@ package_for_arch(Arena *arena, u32 arch, char *cdir, char *build_dir, char *pack
     fm_copy_file(fm_str(arena, build_dir, "/4ed_app" DLL), fm_str(arena, dir, "/4ed_app" DLL));
     fm_copy_file(fm_str(arena, build_dir, "/custom_4coder" DLL), fm_str(arena, dir, "/custom_4coder" DLL));
     
-    if (tier == Tier_Demo){
-        dist_file_count -= 1;
-    }
-    
     for (i32 j = 0; j < dist_file_count; j += 1){
         fm_copy_all(dist_files[j], dir);
     }
     
-    if (tier == Tier_Super){
-        char *custom_src_dir = fm_str(arena, cdir, SLASH, "custom");
-        char *custom_dst_dir = fm_str(arena, dir, SLASH, "custom");
-        fm_make_folder_if_missing(arena, custom_dst_dir);
-        fm_copy_all(custom_src_dir, custom_dst_dir);
-    }
+    char *custom_src_dir = fm_str(arena, cdir, SLASH, "custom");
+    char *custom_dst_dir = fm_str(arena, dir, SLASH, "custom");
+    fm_make_folder_if_missing(arena, custom_dst_dir);
+    fm_copy_all(custom_src_dir, custom_dst_dir);
     
-    char *dist_name = get_4coder_dist_name(arena, This_OS, tier_name, arch);
+    char *dist_name = get_4coder_dist_name(arena, This_OS, arch);
     char *zip_name = fm_str(arena, zip_dir, SLASH, dist_name, ".zip");
     fm_make_folder_if_missing(arena, zip_dir);
     fm_zip(parent_dir, "4coder", zip_name);
 }
 
-internal u32
-tier_flags(Tier_Code code){
-    u32 result = 0;
-    switch (code){
-        case Tier_Super:
-        {
-            result = SUPER;
-        }break;
-    }
-    return(result);
-}
-
 internal void
-package(Arena *arena, char *cdir, Tier_Code tier, Arch_Code arch){
+package(Arena *arena, char *cdir, Arch_Code arch){
     // NOTE(allen): meta
     char *build_dir = fm_str(arena, BUILD_DIR);
     char *pack_dir = fm_str(arena, PACK_DIR);
@@ -677,23 +641,21 @@ package(Arena *arena, char *cdir, Tier_Code tier, Arch_Code arch){
     printf("dist files: %s, %s\n", dist_files[0], dist_files[1]);
     fflush(stdout);
     
-    u32 base_flags = SHIP | DEBUG_INFO | OPTIMIZATION;
+    u32 flags = SHIP | DEBUG_INFO | OPTIMIZATION;
     
 #if OS_WINDOWS
 #if defined( WIN32_DX11 )
-    base_flags |= DX11;
+    flags |= DX11;
 #else
-    base_flags |= OPENGL;
+    flags |= OPENGL;
 #endif
 #endif
     
     fm_make_folder_if_missing(arena, pack_dir);
     
-    char *tier_name = tier_names[tier];
-    u32 flags = base_flags | tier_flags(tier);
     Temp_Memory temp = begin_temp(arena);
-    char *current_dist_tier = fm_str(arena, ".." SLASH "current_dist_", tier_name);
-    package_for_arch(arena, arch, cdir, build_dir, pack_dir, tier, tier_name, current_dist_tier, flags, dist_files, ArrayCount(dist_files));
+    char *current_dist = fm_str(arena, ".." SLASH "current_dist");
+    package_for_arch(arena, arch, cdir, build_dir, pack_dir, current_dist, flags, dist_files, ArrayCount(dist_files));
     end_temp(temp);
 }
 
@@ -723,24 +685,7 @@ int main(int argc, char **argv){
     arch = Arch_X86;
 #endif
     
-#if defined(DEV_BUILD) || defined(OPT_BUILD) || defined(DEV_BUILD_X86) || defined(OPT_BUILD_X86)
-    standard_build(&arena, cdir, flags, arch);
-    
-#elif defined(PACKAGE_DEMO_X64)
-    package(&arena, cdir, Tier_Demo, Arch_X64);
-    
-#elif defined(PACKAGE_DEMO_X86)
-    package(&arena, cdir, Tier_Demo, Arch_X86);
-    
-#elif defined(PACKAGE_SUPER_X64)
-    package(&arena, cdir, Tier_Super, Arch_X64);
-    
-#elif defined(PACKAGE_SUPER_X86)
-    package(&arena, cdir, Tier_Super, Arch_X86);
-    
-#else
-# error No build type specified.
-#endif
+    package(&arena, cdir, arch);
     
     return(error_state);
 }

--- a/code/bin/build-x86-linux.sh
+++ b/code/bin/build-x86-linux.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-ME="$(readlink -f "$0")"
-LOCATION="$(dirname "$ME")"
-$LOCATION/build-linux.sh -DDEV_BUILD_X86
-
-

--- a/code/bin/build-x86.bat
+++ b/code/bin/build-x86.bat
@@ -1,2 +1,0 @@
-@echo off
-bin\build.bat /DDEV_BUILD_X86 %1

--- a/code/bin/package-linux.sh
+++ b/code/bin/package-linux.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-chmod +x bin/build-linux.sh
-bin/build-linux.sh "-DPACKAGE_SUPER_X64"

--- a/code/bin/package-mac.sh
+++ b/code/bin/package-mac.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-chmod +x bin/build-mac.sh
-bin/build-mac.sh "-DPACKAGE_SUPER_X64"

--- a/code/bin/package.bat
+++ b/code/bin/package.bat
@@ -1,3 +1,0 @@
-@echo off
-
-call bin\build.bat /DPACKAGE_SUPER_X64 %1

--- a/code/bin/zip.bat
+++ b/code/bin/zip.bat
@@ -1,9 +1,0 @@
-@echo off
-
-REM Usage: zip <archivename>
-REM compresses the current directory into a zip named <archivename>.zip
-
-SET ZIP_PATH=C:\Program Files (x86)\7-Zip
-IF NOT EXIST "%ZIP_PATH%" (SET ZIP_PATH=C:\Program Files\7-Zip)
-IF EXIST "%ZIP_PATH%" ("%ZIP_PATH%\7z.exe" a -tzip -y %*)
-


### PR DESCRIPTION
I've made the following changes to `4ed_build.cpp`:
- Always create a working 4coder installation
- Put everything in the `build` directory
- Separate builds with `<architecture>` subfolder in build
- Put zip files in the same place as the folder

### Before PR

After doing `cd code && .\bin\package.bat`

```
build\
current_dist_super_x64\
| 4coder\
| | 4ed.exe
distributions\
| 4coder\
| | zipfile
code\
non-source\
.gitignore
README.md
```

### After PR

After doing `cd code && .\bin\package.bat`

```
build\
| x64\
| | 4coder\
| | | 4ed.exe
| | zipfile
code\
non-source\
.gitignore
README.md
```

### Next Step

This is only a first step to unify and simply the build process for 4coder