### PR TITLE
Fix for musl systems and expand context cracking capabilities

### DIFF
--- a/code/custom/4coder_base_types.h
+++ b/code/custom/4coder_base_types.h
@@ -57,7 +57,7 @@
 
 # define COMPILER_GCC 1
 
-# if defined(__gnu_linux__)
+# if defined(__gnu_linux__) || defined(__linux__)
 #  define OS_LINUX 1
 # else
 #  error This compiler/platform combo is not supported yet

--- a/code/custom/4coder_base_types.h
+++ b/code/custom/4coder_base_types.h
@@ -8,128 +8,171 @@
 #define FCODER_BASE_TYPES
 
 ////////////////////////////////
-
 #if defined(_MSC_VER)
-
 # define COMPILER_CL 1
 
 # if defined(_WIN32)
 #  define OS_WINDOWS 1
 # else
-#  error This compiler/platform combo is not supported yet
+#  error missing OS detection
 # endif
 
 # if defined(_M_AMD64)
 #  define ARCH_X64 1
-# elif defined(_M_IX86)
+# elif defined(_M_I86)
 #  define ARCH_X86 1
-# elif defined(_M_ARM64)
-#  define ARCH_ARM64 1
 # elif defined(_M_ARM)
 #  define ARCH_ARM32 1
 # else
-#  error architecture not supported yet
+#  error missing ARCH detection
 # endif
 
-#elif defined(__clang__)
+#elif defined(__clang__) || defined(__GNUC__)
+# if defined(__clang__)
+#  define COMPILER_CLANG 1
+# elif defined(__GNUC__)
+#  define COMPILER_GCC 1
+# endif
 
-# define COMPILER_CLANG 1
-
-# if defined(__APPLE__) && defined(__MACH__)
+# if defined(_WIN32)
+#  define OS_WINDOWS 1
+# elif defined(__gnu_linux__) || defined(__linux__)
+#  define OS_LINUX 1
+# elif defined(__APPLE__) && defined(__MACH__)
 #  define OS_MAC 1
 # else
-#  error This compiler/platform combo is not supported yet
+#  error missing OS detection
 # endif
 
-# if defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64)
+# if defined(__amd64__)
 #  define ARCH_X64 1
-# elif defined(i386) || defined(__i386) || defined(__i386__)
+# elif defined(__i386__)
 #  define ARCH_X86 1
-# elif defined(__aarch64__)
-#  define ARCH_ARM64 1
 # elif defined(__arm__)
 #  define ARCH_ARM32 1
-# else
-#  error architecture not supported yet
-# endif
-
-#elif defined(__GNUC__) || defined(__GNUG__)
-
-# define COMPILER_GCC 1
-
-# if defined(__gnu_linux__) || defined(__linux__)
-#  define OS_LINUX 1
-# else
-#  error This compiler/platform combo is not supported yet
-# endif
-
-# if defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64)
-#  define ARCH_X64 1
-# elif defined(i386) || defined(__i386) || defined(__i386__)
-#  define ARCH_X86 1
 # elif defined(__aarch64__)
 #  define ARCH_ARM64 1
-# elif defined(__arm__)
-#  define ARCH_ARM32 1
 # else
-#  error architecture not supported yet
+#  error missing ARCH detection
 # endif
-
 #else
-# error This compiler is not supported yet
+# error no context cracking for this compiler
 #endif
 
-#if defined(ARCH_X64)
-# define ARCH_64BIT 1
-#elif defined(ARCH_X86)
-# define ARCH_32BIT 1
-
-#endif
-
-// zeroify
-
-#if !defined(ARCH_32BIT)
-#define ARCH_32BIT 0
-#endif
-#if !defined(ARCH_64BIT)
-#define ARCH_64BIT 0
-#endif
-#if !defined(ARCH_X64)
-#define ARCH_X64 0
-#endif
-#if !defined(ARCH_X86)
-#define ARCH_X86 0
-#endif
-#if !defined(ARCH_ARM64)
-#define ARCH_ARM64 0
-#endif
-#if !defined(ARCH_ARM32)
-#define ARCH_ARM32 0
-#endif
 #if !defined(COMPILER_CL)
-#define COMPILER_CL 0
-#endif
-#if !defined(COMPILER_GCC)
-#define COMPILER_GCC 0
+# define COMPILER_CL 0
 #endif
 #if !defined(COMPILER_CLANG)
-#define COMPILER_CLANG 0
+# define COMPILER_CLANG 0
+#endif
+#if !defined(COMPILER_GCC)
+# define COMPILER_GCC 0
 #endif
 #if !defined(OS_WINDOWS)
-#define OS_WINDOWS 0
+# define OS_WINDOWS 0
 #endif
 #if !defined(OS_LINUX)
-#define OS_LINUX 0
+# define OS_LINUX 0
 #endif
 #if !defined(OS_MAC)
-#define OS_MAC 0
+# define OS_MAC 0
+#endif
+#if !defined(ARCH_X64)
+# define ARCH_X64 0
+#endif
+#if !defined(ARCH_X86)
+# define ARCH_X86 0
+#endif
+#if !defined(ARCH_ARM32)
+# define ARCH_ARM32 0
+#endif
+#if !defined(ARCH_ARM64)
+# define ARCH_ARM64 0
 #endif
 
-#if !defined(SHIP_MODE)
-#define SHIP_MODE 0
+// language
+#if defined(__cplusplus)
+# define LANG_CXX 1
 #else
-#undef SHIP_MODE
-#define SHIP_MODE 1
+# define LANG_C 1
+#endif
+
+#if !defined(LANG_CXX)
+# define LANG_CXX 0
+#endif
+#if !defined(LANG_C)
+# define LANG_C 0
+#endif
+
+// language version: C
+#if LANG_C
+# if !defined(__STDC_VERSION__)
+#  define LANGVER_C90 1
+# elif (__STDC_VERSION__ == 199901)
+#  define LANGVER_C99 1
+# elif (__STDC_VERSION__ == 201112)
+#  define LANGVER_C11 1
+# elif (__STDC_VERSION__ == 201710)
+#  define LANGVER_C17 1
+# elif (__STDC_VERSION__ == 202000)
+#  define LANGVER_C23 1
+# else
+#  error unrecorgnized C version
+# endif
+#endif
+
+#if !defined(LANGVER_C90)
+# define LANGVER_C90 0
+#endif
+#if !defined(LANGVER_C99)
+# define LANGVER_C99 0
+#endif
+#if !defined(LANGVER_C11)
+# define LANGVER_C11 0
+#endif
+#if !defined(LANGVER_C17)
+# define LANGVER_C17 0
+#endif
+#if !defined(LANGVER_C23)
+# define LANGVER_C23 0
+#endif
+
+// language version: C++
+#if LANG_CXX
+# if (__cplusplus == 199711)
+#  define LANGVER_CXX98 1
+# elif (__cplusplus == 201103)
+#  define LANGVER_CXX11 1
+# elif (__cplusplus == 201402)
+#  define LANGVER_CXX14 1
+# elif (__cplusplus == 201703)
+#  define LANGVER_CXX17 1
+# elif (__cplusplus == 202002)
+#  define LANGVER_CXX20 1
+# elif (__cplusplus == 202302)
+#  define LANGVER_CXX23 1
+# else
+#  error unrecorgnized C++ version
+# endif
+#endif
+
+#if !defined(LANGVER_CXX98)
+# define LANGVER_CXX98 0
+#endif
+#if !defined(LANGVER_CXX11)
+# define LANGVER_CXX11 0
+#endif
+#if !defined(LANGVER_CXX14)
+# define LANGVER_CXX14 0
+#endif
+#if !defined(LANGVER_CXX17)
+# define LANGVER_CXX17 0
+#endif
+#if !defined(LANGVER_CXX20)
+# define LANGVER_CXX20 0
+#endif
+#if !defined(LANGVER_CXX23)
+# define LANGVER_CXX23 0
 #endif
 
 // names

--- a/code/custom/4coder_base_types.h
+++ b/code/custom/4coder_base_types.h
@@ -175,6 +175,14 @@
 # define LANGVER_CXX23 0
 #endif
 
+#if !defined(SHIP_MODE)
+# define SHIP_MODE 0
+#else
+# undef SHIP_MODE
+# define SHIP_MODE 1
+#endif 
+
+
 // names
 
 #if COMPILER_CL

--- a/code/platform_linux/linux_4ed_functions.cpp
+++ b/code/platform_linux/linux_4ed_functions.cpp
@@ -67,7 +67,10 @@ system_get_canonical(Arena* arena, String_Const_u8 name){
     
     // first remove redundant ../, //, ./ parts
     
-    const u8* input = (u8*) strndupa((char*)name.str, name.size);
+    char *tmp = (char*)alloca(name.size + 1);
+    memcpy(tmp, name.str, name.size);
+    tmp[name.size] = 0;
+    const u8* input = (u8*)tmp;
     u8* output = push_array(arena, u8, name.size + 1);
     
     const u8* p = input;
@@ -122,7 +125,9 @@ system_get_file_list(Arena* arena, String_Const_u8 directory){
     //LINUX_FN_DEBUG("%.*s", (int)directory.size, directory.str);
     File_List result = {};
     
-    char* path = strndupa((char*)directory.str, directory.size);
+    char *path = (char*)alloca(directory.size + 1);
+    memcpy(path, directory.str, directory.size);
+    path[directory.size] = 0;
     int fd = open(path, O_RDONLY | O_DIRECTORY);
     if(fd == -1) {
         perror("open");
@@ -168,7 +173,7 @@ system_get_file_list(Arena* arena, String_Const_u8 directory){
             *fip++ = f;
         }
         
-        qsort(result.infos, result.count, sizeof(File_Info*), (__compar_fn_t)&linux_compare_file_infos);
+        qsort(result.infos, result.count, sizeof(File_Info*), (int(*)(const void*, const void*))&linux_compare_file_infos);
         
         for(u32 i = 0; i < result.count - 1; ++i) {
             result.infos[i]->next = result.infos[i+1];
@@ -334,7 +339,7 @@ function
 system_universal_date_time_from_local_sig(){
     struct tm local_tm = {};
     linux_tm_from_date_time(&local_tm, date_time);
-    time_t loc_time = timelocal(&local_tm);
+    time_t loc_time = mktime(&local_tm);
     struct tm *utc_tm = gmtime(&loc_time);
     Date_Time result = {};
     linux_date_time_from_tm(&result, utc_tm);

--- a/code/platform_linux/linux_4ed_functions.cpp
+++ b/code/platform_linux/linux_4ed_functions.cpp
@@ -71,10 +71,13 @@ system_get_canonical(Arena* arena, String_Const_u8 name){
     char real[PATH_MAX] = { 0 };
     realpath(tmp, real);
     
-    String_Const_u8 result = SCu8((u8*)real, cstring_length(real));
+    String_Const_u8 result = push_string_copy(arena,
+                                              SCu8((u8*)real, cstring_length(real)));
 #ifdef INSO_DEBUG
-    if(name.size != q - output) {
-        LINUX_FN_DEBUG("[%.*s] -> [%s]", (int)name.size, name.str, real);
+    if(name.size != result.size) {
+        LINUX_FN_DEBUG("[%.*s] -> [%.*s]",
+                       (int)name.size, name.str,
+                       (int)result.size, result.str);
     }
 #endif
     return result;
@@ -91,6 +94,7 @@ system_get_file_list(Arena* arena, String_Const_u8 directory){
 
     int fd = open(path, O_RDONLY | O_DIRECTORY);
     if(fd == -1) {
+        LINUX_FN_DEBUG("Failed to open directory: %.*s", (int)directory.size, directory.str);
         perror("open");
         return result;
     }
@@ -218,6 +222,7 @@ system_save_file(Arena* scratch, char* file_name, String_Const_u8 data){
         }
         close(fd);
     } else {
+        LINUX_FN_DEBUG("Failed to open file: %s", file_name);
         perror("open");
     }
     


### PR DESCRIPTION
The 4coder build fails on non glibc linux systems due to non-standard GNU extensions used in the linux platform layer. This PR is a continuation of #56 which was closed due to the submitter deleting his repository.
It:
- removes the use of GCC extensions
  - replace `strndupa` with a `strcpy` into a fixed sized buffer (with size PATH_MAX)
  - replace `localtime` with `mktime`
- Addresses a TODO in the linux platform's `system_get_cannonical` function
  - replaces custom string with `realpath`
- update context cracking in `4coder_base_types.h` to be more thorough, should also enable the use clang on windows and linux rather than just msvc and gcc respectively
- Add ` || defined(__linux__)`  to linux os cracking as musl defines that over `__gnu_linux__`